### PR TITLE
Fix notch height

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -210,10 +210,10 @@
                 <string ...>M -5,0 L -5,10 L 5,10 L 5,0 Z @dp</string>
          @see https://www.w3.org/TR/SVG/paths.html#PathData
          -->
-    <string translatable="false" name="config_mainBuiltInDisplayCutout">M -270,0 L -270,89 L 270,89 L 270,0 Z</string>
+    <string translatable="false" name="config_mainBuiltInDisplayCutout">M -270,0 L -270,87 L 270,87 L 270,0 Z</string>
 
     <!-- Height of the status bar -->
-    <dimen name="status_bar_height_portrait">89.0px</dimen>
+    <dimen name="status_bar_height_portrait">87.0px</dimen>
     <dimen name="status_bar_height_landscape">24.0dp</dimen>
 
     <!-- Whether the device has outdated qti-telephony-common.jar -->


### PR DESCRIPTION
The notch is closer to 87dp tall than 89dp. It's 87 in the stock MIUI ROM, as well.